### PR TITLE
[#1] 6. Bean Scope 알아보기

### DIFF
--- a/src/test/java/com/jokim/scope/ScopeTests.java
+++ b/src/test/java/com/jokim/scope/ScopeTests.java
@@ -4,13 +4,17 @@ import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
 
 public class ScopeTests {
 
-    private static final AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(SingletonBean.class, PrototypeBean.class);
+    private static final AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(
+        SingletonBean.class, PrototypeBean.class, PrototypeProxyModeBean.class
+        );
 
     @Test
     @DisplayName("[Success]Singleton Scope 테스트")
@@ -33,7 +37,7 @@ public class ScopeTests {
         // assert
         assertThat(prototypeBean1).isNotSameAs(prototypeBean2);
     }
-    
+
     @Test
     @DisplayName("[Success]Singleton Bean에 주입된 Prototype Bean은 같음")
     void singletonBeanTestWithPrototype() {
@@ -49,26 +53,78 @@ public class ScopeTests {
         assertThat(prototypeBean1).isSameAs(prototypeBean2);
     }
 
+    @Test
+    @DisplayName("[Success]Singleton Bean에서 Provider로 Prototype Bean 조회 테스트")
+    void singletonBeanTestWithPrototypeFromProvider() {
+        // arrange
+        SingletonBean singletonBean1 = ac.getBean(SingletonBean.class);
+        SingletonBean singletonBean2 = ac.getBean(SingletonBean.class);
 
+        // act
+        PrototypeBean prototypeBean1 = singletonBean1.getPrototypeBeanFromProvider();
+        PrototypeBean prototypeBean2 = singletonBean2.getPrototypeBeanFromProvider();
 
+        // assert
+        assertThat(prototypeBean1).isNotSameAs(prototypeBean2);
+    }
+
+    @Test
+    @DisplayName("[Success]Singleton Bean에서 Provider로 Prototype Bean 조회 테스트")
+    void singletonBeanTestWithPrototypeProxyModeBean() {
+        // arrange
+        SingletonBean singletonBean1 = ac.getBean(SingletonBean.class);
+        SingletonBean singletonBean2 = ac.getBean(SingletonBean.class);
+        
+        // act
+        PrototypeProxyModeBean prototypeProxyModeBean1 = singletonBean1.getPrototypeProxyModeBean();
+        PrototypeProxyModeBean prototypeProxyModeBean2 = singletonBean2.getPrototypeProxyModeBean();
+
+        // assert
+        assertThat(prototypeProxyModeBean1.hashCode()).isNotSameAs(prototypeProxyModeBean2.hashCode());
+    }
 
 
     @Scope(value = "singleton")
     static class SingletonBean {
         private final PrototypeBean prototypeBean;
+        private final ObjectProvider<PrototypeBean> prototypeBeanProvider;
+        private final PrototypeProxyModeBean prototypeProxyModeBean;
 
         @Autowired
-        public SingletonBean(PrototypeBean prototypeBean) {
+        public SingletonBean(PrototypeBean prototypeBean, ObjectProvider<PrototypeBean> prototypeBeanProvider, PrototypeProxyModeBean prototypeProxyModeBean) {
             this.prototypeBean = prototypeBean;
+            this.prototypeBeanProvider = prototypeBeanProvider;
+            this.prototypeProxyModeBean = prototypeProxyModeBean;
         }
 
         public PrototypeBean getPrototypeBean() {
             return prototypeBean;
+        }
+
+        public PrototypeBean getPrototypeBeanFromProvider() {
+            return prototypeBeanProvider.getObject();
+        }
+
+        public PrototypeProxyModeBean getPrototypeProxyModeBean() {
+            prototypeProxyModeBean.doSomething();
+            return prototypeProxyModeBean;
         }
     }
 
     @Scope(value = "prototype")
     static class PrototypeBean {
     
+    }
+
+    @Scope(value = "prototype", proxyMode = ScopedProxyMode.TARGET_CLASS)
+    static class PrototypeProxyModeBean {
+        private int count = 0;
+        public void doSomething() {
+            count++;
+        }
+
+        public int getCount() {
+            return count;
+        }
     }
 }


### PR DESCRIPTION
### Scope의 `Singleton`, `Prototype`에 대해서 알아보고 특징테스트해보기

### `Singleton`에서 `Prototype` 사용했을 때 문제점에 대해서 알아보고 해결 방법으로 테스트 해보기
* Provider 사용해보기
* Porxymode 사용해보기

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `ScopeTests` covering singleton vs prototype behavior, provider-based prototype retrieval, and scoped-proxy behavior using inner bean definitions.
> 
> - **Tests (`src/test/java/com/jokim/scope/ScopeTests.java`)**
>   - Add `ScopeTests` verifying:
>     - `singleton` scope returns the same instance; `prototype` returns new instances.
>     - `singleton` injected `prototype` remains the same instance vs `ObjectProvider` provides fresh instances.
>     - `ScopedProxyMode.TARGET_CLASS` on a `prototype` bean yields distinct proxied instances per access.
>   - Define inner beans: `SingletonBean`, `PrototypeBean`, and `PrototypeProxyModeBean` (prototype with proxy).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aea4813232057d02a85a8a4b731bef655912b36e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->